### PR TITLE
Track systs

### DIFF
--- a/IDTrackSel/JetTrackFilterToolAlgo.h
+++ b/IDTrackSel/JetTrackFilterToolAlgo.h
@@ -14,7 +14,7 @@ class JetTrackFilterToolAlgo : public EL::Algorithm
 {
 public:
   std::string m_name = "MattLeBlanc";
-  std::string m_JetContainerName = "AntiKt4EMTopoJets";
+  std::string m_JetContainerName = "AntiKt10LCTopoJets";
   std::string m_inputTrackContainer;
   std::string m_outputTrackContainer;
 

--- a/IDTrackSel/TrackVertexAssociationToolAlgo.h
+++ b/IDTrackSel/TrackVertexAssociationToolAlgo.h
@@ -18,7 +18,7 @@ class TrackVertexAssociationToolAlgo : public EL::Algorithm
   std::string m_name = "MattLeBlanc";
   std::string m_inputTrackContainer;
   std::string m_outputTrackContainer;
-  std::string m_workingPoint="loose";
+  std::string m_workingPoint;
 
   Bool_t m_debug=false;
 

--- a/IDTrackSel/TrackVertexAssociationToolAlgo.h
+++ b/IDTrackSel/TrackVertexAssociationToolAlgo.h
@@ -1,5 +1,5 @@
-#ifndef IDTrackSel_JetTrackFilterToolAlgo_H
-#define IDTrackSel_JetTrackFilterToolAlgo_H
+#ifndef IDTrackSel_TrackVertexAssociationToolAlgo_H
+#define IDTrackSel_TrackVertexAssociationToolAlgo_H
 
 #include <EventLoop/Algorithm.h>
 
@@ -7,36 +7,31 @@
 #include <xAODRootAccess/TEvent.h>
 #include <xAODRootAccess/TStore.h>
 
-#include "InDetTrackSystematicsTools/JetTrackFilterTool.h"
+#include "TrackVertexAssociationTool/TrackVertexAssociationTool.h"
+
+#include "xAODTracking/VertexContainer.h"
 #include "xAODTracking/TrackParticleContainer.h"
 
-class JetTrackFilterToolAlgo : public EL::Algorithm
+class TrackVertexAssociationToolAlgo : public EL::Algorithm
 {
-public:
+ public:
   std::string m_name = "MattLeBlanc";
-  std::string m_JetContainerName = "AntiKt4EMTopoJets";
   std::string m_inputTrackContainer;
   std::string m_outputTrackContainer;
+  std::string m_workingPoint;
 
-  // put the tool parameters here
+  Bool_t m_debug=false;
 
-  Bool_t m_debug;
-    
  private:
   xAOD::TEvent *m_event; //!
   xAOD::TStore *m_store; //!
 
-  InDet::JetTrackFilterTool* m_JetTrackFilterTool; //!
+  CP::TrackVertexAssociationTool* m_TrktoVxTool; //!  
 
-  CP::SystematicSet m_systSetJet = {
-    InDet::TrackSystematicMap[InDet::TRK_EFF_LOOSE_TIDE],
-    InDet::TrackSystematicMap[InDet::TRK_FAKE_RATE_LOOSE_TIDE]
-  };
-  
  public:
   // this is a standard constructor
-  JetTrackFilterToolAlgo ();
-
+  TrackVertexAssociationToolAlgo ();
+  
   // these are the functions inherited from Algorithm
   virtual EL::StatusCode setupJob (EL::Job& job);
   virtual EL::StatusCode fileExecute ();
@@ -49,7 +44,7 @@ public:
   virtual EL::StatusCode histFinalize ();
 
   // this is needed to distribute the algorithm to the workers
-  ClassDef(JetTrackFilterToolAlgo, 1);
+  ClassDef(TrackVertexAssociationToolAlgo, 1);
 };
 
 #endif

--- a/IDTrackSel/TrackVertexAssociationToolAlgo.h
+++ b/IDTrackSel/TrackVertexAssociationToolAlgo.h
@@ -18,7 +18,7 @@ class TrackVertexAssociationToolAlgo : public EL::Algorithm
   std::string m_name = "MattLeBlanc";
   std::string m_inputTrackContainer;
   std::string m_outputTrackContainer;
-  std::string m_workingPoint;
+  std::string m_workingPoint="loose";
 
   Bool_t m_debug=false;
 

--- a/Root/InDetTrackBiasingToolAlgo.cxx
+++ b/Root/InDetTrackBiasingToolAlgo.cxx
@@ -91,7 +91,7 @@ EL::StatusCode InDetTrackBiasingToolAlgo :: execute ()
       // Correct the tracks and push back into the new container
       xAOD::TrackParticle* newTrack = nullptr;
       m_InDetTrackBiasingTool->correctedCopy( *track, newTrack );      
-      biasedTracks->push_back(track);
+      biasedTracks->push_back(newTrack);
       delete newTrack;
     }
 

--- a/Root/InDetTrackTruthFilterToolAlgo.cxx
+++ b/Root/InDetTrackTruthFilterToolAlgo.cxx
@@ -36,7 +36,7 @@ EL::StatusCode InDetTrackTruthFilterToolAlgo :: initialize ()
   CP::SystematicSet systSetTrk = {};
   if(m_systematic=="incl")
     {
-      CP::SystematicSet systSetTrk = {
+       systSetTrk = {
 	InDet::TrackSystematicMap[InDet::TRK_EFF_TIGHT_GLOBAL],
 	InDet::TrackSystematicMap[InDet::TRK_EFF_TIGHT_IBL],
 	InDet::TrackSystematicMap[InDet::TRK_EFF_TIGHT_PP0],

--- a/Root/InDetTrackTruthFilterToolAlgo.cxx
+++ b/Root/InDetTrackTruthFilterToolAlgo.cxx
@@ -45,7 +45,7 @@ EL::StatusCode InDetTrackTruthFilterToolAlgo :: initialize ()
     }
   if(m_systematic=="fake")
     {
-      CP::SystematicSet systSetTrk = {
+      systSetTrk = {
 	InDet::TrackSystematicMap[InDet::TRK_FAKE_RATE_LOOSE]
       };
     }

--- a/Root/LinkDef.h
+++ b/Root/LinkDef.h
@@ -1,4 +1,4 @@
-#include <IDTrackSel/TightTrackVertexAssociationToolAlgo.h>
+#include <IDTrackSel/TrackVertexAssociationToolAlgo.h>
 #include <IDTrackSel/InDetTrackSelectionToolAlgo.h>
 #include <IDTrackSel/JetTrackFilterToolAlgo.h>
 #include <IDTrackSel/InDetTrackBiasingToolAlgo.h>
@@ -20,6 +20,10 @@
 
 #ifdef __CINT__
 #pragma link C++ class TightTrackVertexAssociationToolAlgo+;
+#endif
+
+#ifdef __CINT__
+#pragma link C++ class TrackVertexAssociationToolAlgo+;
 #endif
 
 #ifdef __CINT__

--- a/Root/TrackVertexAssociationToolAlgo.cxx
+++ b/Root/TrackVertexAssociationToolAlgo.cxx
@@ -1,18 +1,18 @@
 #include <EventLoop/Job.h>
 #include <EventLoop/StatusCode.h>
 #include <EventLoop/Worker.h>
-#include <IDTrackSel/TightTrackVertexAssociationToolAlgo.h>
+#include <IDTrackSel/TrackVertexAssociationToolAlgo.h>
 
 #include <EventLoop/OutputStream.h>
 
 #include <AsgTools/MessageCheck.h>
 
 // this is needed to distribute the algorithm to the workers
-ClassImp(TightTrackVertexAssociationToolAlgo)
+ClassImp(TrackVertexAssociationToolAlgo)
 
-TightTrackVertexAssociationToolAlgo :: TightTrackVertexAssociationToolAlgo () {}
+TrackVertexAssociationToolAlgo :: TrackVertexAssociationToolAlgo () {}
 
-EL::StatusCode TightTrackVertexAssociationToolAlgo :: setupJob (EL::Job& job)
+EL::StatusCode TrackVertexAssociationToolAlgo :: setupJob (EL::Job& job)
 {
   ANA_CHECK_SET_TYPE (EL::StatusCode);
   job.useXAOD();
@@ -21,35 +21,26 @@ EL::StatusCode TightTrackVertexAssociationToolAlgo :: setupJob (EL::Job& job)
   return EL::StatusCode::SUCCESS;
 }
 
-EL::StatusCode TightTrackVertexAssociationToolAlgo :: histInitialize () { return EL::StatusCode::SUCCESS; }
+EL::StatusCode TrackVertexAssociationToolAlgo :: histInitialize () { return EL::StatusCode::SUCCESS; }
 
-EL::StatusCode TightTrackVertexAssociationToolAlgo :: fileExecute () { return EL::StatusCode::SUCCESS; }
+EL::StatusCode TrackVertexAssociationToolAlgo :: fileExecute () { return EL::StatusCode::SUCCESS; }
 
-EL::StatusCode TightTrackVertexAssociationToolAlgo :: changeInput (bool firstFile) { return EL::StatusCode::SUCCESS; }
+EL::StatusCode TrackVertexAssociationToolAlgo :: changeInput (bool firstFile) { return EL::StatusCode::SUCCESS; }
 
-EL::StatusCode TightTrackVertexAssociationToolAlgo :: initialize ()
+EL::StatusCode TrackVertexAssociationToolAlgo :: initialize ()
 {
-  Info("initialize()", "TightTrackVertexAssociationToolAlgo_%s", m_inputTrackContainer.c_str() );
+  Info("initialize()", "TrackVertexAssociationToolAlgo_%s", m_inputTrackContainer.c_str() );
   m_event = wk()->xaodEvent();
   m_store = wk()->xaodStore();
   
-  m_TightTrktoVxTool = new CP::TightTrackVertexAssociationTool("TightTrackVertexAssociationTool/"+m_name);
-
-  if(m_dzSinTheta_cut!=-999)
-    ANA_CHECK( m_TightTrktoVxTool->setProperty("dzSinTheta_cut", m_dzSinTheta_cut) ); // mm
-  
-  if(m_d0_cut!=-999)
-    ANA_CHECK( m_TightTrktoVxTool->setProperty("d0_cut", m_d0_cut) ); // mm
-
-  ANA_CHECK( m_TightTrktoVxTool->setProperty("Applyd0Selection",m_Applyd0Selection) );
-  ANA_CHECK( m_TightTrktoVxTool->setProperty("doPV",m_doPV) );
-
-  ANA_CHECK( m_TightTrktoVxTool->initialize() );
+  m_TrktoVxTool = new CP::TrackVertexAssociationTool( "TrackVertexAssociationTool/"+m_name );
+  ANA_CHECK(m_TrktoVxTool->setProperty( "WorkingPoint", m_workingPoint));
+  ANA_CHECK(m_TrktoVxTool->initialize());
 
   return EL::StatusCode::SUCCESS;
 }
 
-EL::StatusCode TightTrackVertexAssociationToolAlgo :: execute ()
+EL::StatusCode TrackVertexAssociationToolAlgo :: execute ()
 {
   // Find the PV
        
@@ -91,7 +82,7 @@ EL::StatusCode TightTrackVertexAssociationToolAlgo :: execute ()
       continue;
 
     // If the track ain't associated with the primary vertex, don't take a track ...
-    if(!m_TightTrktoVxTool->isCompatible(*track,*primaryVertex)) 
+    if(!m_TrktoVxTool->isCompatible(*track,*primaryVertex)) 
       {
 	//if(m_debug) Info("execute()","track rejected");
 	//Info("execute()","track rejected");
@@ -108,8 +99,8 @@ EL::StatusCode TightTrackVertexAssociationToolAlgo :: execute ()
   return EL::StatusCode::SUCCESS;
 }
 
-EL::StatusCode TightTrackVertexAssociationToolAlgo :: postExecute () { return EL::StatusCode::SUCCESS; }
+EL::StatusCode TrackVertexAssociationToolAlgo :: postExecute () { return EL::StatusCode::SUCCESS; }
 
-EL::StatusCode TightTrackVertexAssociationToolAlgo :: finalize () { return EL::StatusCode::SUCCESS; }
+EL::StatusCode TrackVertexAssociationToolAlgo :: finalize () { return EL::StatusCode::SUCCESS; }
 
-EL::StatusCode TightTrackVertexAssociationToolAlgo :: histFinalize () { return EL::StatusCode::SUCCESS; }
+EL::StatusCode TrackVertexAssociationToolAlgo :: histFinalize () { return EL::StatusCode::SUCCESS; }


### PR DESCRIPTION
**Summary**
IDTrackSel/Root/InDetTrackTruthFilterToolAlgo: 
 
Changed cuts from tight to loose
Line 36 of the new repository used to be inside the if statement and was not stored. Also changed CP::SystematicSet systSetTrk{...} within the if statement to systSetTrk{...} (https://gitlab.cern.ch/krybacki/IDTrackSel/-/blob/master/Root/InDetTrackTruthFilterToolAlgo.cxx#L39) to not overwrite the systSetTrk, same issue with it not being stored otherwise
 

IDTrackSel/Root/InDetTrackBiasingToolAlgo: 
The systematic variations were not defined and thus nothing was applied
The nominal tracks were stored again and not those that are modified beforehand (i.e. newTrack) 
Changes are in this commit: https://gitlab.cern.ch/krybacki/IDTrackSel/-/commit/478160a00f0c928e343159f3befefe20d32aaa6e

IDTrackSel/Root/TightTrackVertexAssociationToolAlgo:
 
The TightTrackVertexAssociationTool is not supported anymore by the tracking group and shouldn’t be used anymore. Instead use the TrackVertexAssociationTool, so updated the LinkDef.
 

IDTrackSel/IDTrackSel/JetTrackFilterToolAlgo:
 
Added to the header file, the fake rate in dense environments systematic: InDet::TrackSystematicMap[InDet::TRK_FAKE_RATE_LOOSE_TIDE]
 

 
Changed to using AntiKt4EMTopo jets.